### PR TITLE
Ensure marmottawrapper has minimal external dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .extract/*
-marmotta/target/*
+marmotta/*
 Gemfile.lock
 .vagrant
 *.gem

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Download and install Marmotta:
 * To start a Marmotta app in Tomcat 7 on port `8080`: `rake marmotta:start`
 * To stop Tomcat: `rake marmotta:stop`
 
+
+Configuration
+-------------
+
+By default, Marmotta will create all its necessary files in a `marmotta`
+subdirectory of your application's root once you start it for the first time,
+including sensible defaults for configuration. Configuration changes can be
+made by altering `marmotta/system-config.properties` (see the
+[Marmotta documentation](http://marmotta.apache.org/configuration.html)
+for more details).
+
 Use in Rails Projects
 ----------------------
 
@@ -43,7 +54,7 @@ Marmotta should now be available on your host machine at port `8087`.
 TODO:
 -----
 * [ ] Make Tomcat port configurable.
-* [ ] Make Marmotta configurable.
 * [ ] Wait for Tomcat to start before quitting `start` task.
+* [ ] Add support for Windows.
 
 License: Apache 2.0

--- a/lib/marmottawrapper/tasks/marmottawrapper.rake
+++ b/lib/marmottawrapper/tasks/marmottawrapper.rake
@@ -17,19 +17,19 @@ namespace :marmotta do
 
   desc "Start Marmotta/Tomcat"
   task :start do
-    pid = Marmottawrapper.start
-    puts "Tomcat started with PID #{pid}"
+    Marmottawrapper.start
   end
 
   desc "Stop Marmotta/Tomcat"
   task :stop do
-    pid = Marmottawrapper.stop
-    puts "Tomcat/Marmotta stopped"
+    Marmottawrapper.stop
   end
 
   desc "Restart Marmotta/Tomcat"
   task :restart do
     Marmottawrapper.stop
+    sleep 2
     Marmottawrapper.start
   end
+
 end

--- a/marmottawrapper.gemspec
+++ b/marmottawrapper.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.license       = 'APACHE 2'
   
   s.add_dependency 'rake'
+  s.add_dependency 'archive-tar-minitar'
   s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
- Use `#{app_root}/marmotta` as the data directory...for real
- `marmottawrapper` now no longer depends on `curl` and `unzip`
  - `rake marmotta:fetch` uses `open-uri` and grabs a tarball
  - `rake marmotta:install` uses `Archive::Tar::Minitar` and `GZip`
- Update README to describe Marmotta configuration conventions 

Specifically, once Marmotta creates its required files on its first startup, users can then modify the default configuration.
