### PR TITLE
Add rake tasks to non-Rails projects

### DIFF
--- a/lib/marmottawrapper.rb
+++ b/lib/marmottawrapper.rb
@@ -3,6 +3,7 @@ require 'fileutils'
 class Marmottawrapper
 
   require 'marmottawrapper/railtie' if defined?(Rails)
+  Dir[File.expand_path(File.join(File.dirname(__FILE__),"marmottawrapper/tasks/*.rake"))].each { |ext| load ext } if defined?(Rake)
 
   class << self
     def app_root


### PR DESCRIPTION
Marmottawrapper tasks were previously only added to rails projects,
this adds them to environments where Rake exists, but Rails does not.
